### PR TITLE
Add: 프레임 테이블을 위한 리스트 구조체 및 관련 함수 구현

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -34,6 +34,7 @@ enum vm_type {
 
 struct page_operations;
 struct thread;
+struct list frame_table;
 
 #define VM_TYPE(type) ((type) & 7)
 
@@ -64,6 +65,7 @@ struct page {
 struct frame {
     void *kva;
     struct page *page;
+    struct list_elem frame_elem;
 };
 
 /* The function table for page operations.


### PR DESCRIPTION
`Implement frame table and page eviction using FIFO algorithm`

## 구현한 내용

이 PR에서는 페이지 프레임 관리를 위한 `frame_table`을 도입하고, 프레임 부족 시 FIFO 방식으로 페이지를 교체(eviction)하는 로직을 구현

### 주요 변경 사항

1. **`frame_table` 전역 변수 추가**

   * `vm.c`와 `vm.h`에 `struct list frame_table;`을 선언
   * `vm_init()` 함수에서 `list_init(&frame_table)`을 호출하여 초기화

2. **프레임 할당 함수 수정 (`vm_get_frame`)**

   * 유저 페이지 할당 실패 시 `vm_evict_frame()`을 호출하여 프레임을 회수
   * 프레임 할당 시 `frame_table`에 `list_push_back()`으로 프레임 추가

3. **페이지 교체 함수 구현**

   * `vm_get_victim()`:

     * FIFO 정책으로 가장 먼저 들어온 프레임을 선택 (`list_pop_front()`)
   * `vm_evict_frame()`:

     * victim을 선택하고 `swap_out()`을 호출하여 페이지 스왑 후 프레임 반환

4. **프레임 구조체 수정**

   * `struct frame`에 `struct list_elem frame_elem` 추가하여 리스트에 연결 가능하도록 수정


## 🧩 관련 파일

* `include/vm/vm.h`
* `vm/vm.c`

---

