### PR TITLE
feat : spt_find_page, spt_insert_page 함수 구현 / fix : page 구조체 hash_elem, writable 변수 추가, json define VM,USERPROG 추가

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -47,6 +47,8 @@ struct page {
     struct frame *frame; /* Back reference for frame */
 
     /* Your implementation */
+    struct hash_elem hash_elem;
+    bool writable;
 
     /* Per-type data are binded into the union.
      * Each function automatically detects the current union */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -57,19 +57,32 @@ err:
     return false;
 }
 
-/* Find VA from spt and return page. On error, return NULL. */
-struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-    struct page *page = NULL;
+/// @brief SPT에서 가상 주소 va에 해당하는 struct page *를 찾습니다.
+struct page *spt_find_page(struct supplemental_page_table *spt, void *va) {
+    struct page temp_page;
     /* TODO: Fill this function. */
+    temp_page.va = pg_round_down(va);
 
-    return page;
+
+    struct hash_elem *found_element = hash_find(&spt->spt_hash, &temp_page.hash_elem);
+
+    if (found_element != NULL)
+        return hash_entry(found_element, struct page, hash_elem);
+    else
+        return NULL;
 }
 
-/* Insert PAGE into spt with validation. */
-bool spt_insert_page(struct supplemental_page_table *spt UNUSED, struct page *page UNUSED) {
+/// @brief page->va를 기준으로 SPT에 페이지 등록, 중복 시 false
+/// @param spt (페이지를 등록할 보조 페이지 테이블의 포인터)
+/// @param page (등록할 페이지의 정보가 담긴 구조체의 포인터)
+/// @return 삽입에 성공하면 true, 가상 주소가 중복되어 실패하면 false
+bool spt_insert_page(struct supplemental_page_table *spt , struct page *page ) {
     int succ = false;
-    /* TODO: Fill this function. */
-
+    struct hash_elem *result = hash_insert(&spt->spt_hash, &page->hash_elem);
+    
+    if(result == NULL){
+        succ = true;
+    }
     return succ;
 }
 


### PR DESCRIPTION
### 구현한 내용
- 보조 페이지 테이블(SPT)에서 페이지를 해시 기반으로 검색하는 spt_find_page 함수 구현
- 페이지를 SPT에 중복 없이 삽입하는 spt_insert_page 함수 구현
- 페이지 구조체에 해시 엘리먼트와 쓰기 가능 여부 멤버(hash_elem, writable) 추가

파일 | 변경 내용
-- | --
include/vm/vm.h | struct page에 hash_elem, bool writable 필드 추가
vm/vm.c | - spt_find_page: 해시 기반으로 SPT에서 페이지 검색 구현- spt_insert_page: 페이지 중복 검사 후 SPT에 삽입 기능 구현



### 관련 파일
- include/vm/vm.h
- vm/vm.c