### PR TITLE
Feat/vm do claim page

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -47,6 +47,8 @@ struct page {
     struct frame *frame; /* Back reference for frame */
 
     /* Your implementation */
+    struct hash_elem hash_elem;
+    bool writable;
 
     /* Per-type data are binded into the union.
      * Each function automatically detects the current union */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -57,19 +57,32 @@ err:
     return false;
 }
 
-/* Find VA from spt and return page. On error, return NULL. */
-struct page *spt_find_page(struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-    struct page *page = NULL;
+/// @brief SPT에서 가상 주소 va에 해당하는 struct page *를 찾습니다.
+struct page *spt_find_page(struct supplemental_page_table *spt, void *va) {
+    struct page temp_page;
     /* TODO: Fill this function. */
+    temp_page.va = pg_round_down(va);
 
-    return page;
+
+    struct hash_elem *found_element = hash_find(&spt->spt_hash, &temp_page.hash_elem);
+
+    if (found_element != NULL)
+        return hash_entry(found_element, struct page, hash_elem);
+    else
+        return NULL;
 }
 
-/* Insert PAGE into spt with validation. */
-bool spt_insert_page(struct supplemental_page_table *spt UNUSED, struct page *page UNUSED) {
+/// @brief page->va를 기준으로 SPT에 페이지 등록, 중복 시 false
+/// @param spt (페이지를 등록할 보조 페이지 테이블의 포인터)
+/// @param page (등록할 페이지의 정보가 담긴 구조체의 포인터)
+/// @return 삽입에 성공하면 true, 가상 주소가 중복되어 실패하면 false
+bool spt_insert_page(struct supplemental_page_table *spt , struct page *page ) {
     int succ = false;
-    /* TODO: Fill this function. */
-
+    struct hash_elem *result = hash_insert(&spt->spt_hash, &page->hash_elem);
+    
+    if(result == NULL){
+        succ = true;
+    }
     return succ;
 }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -153,16 +153,26 @@ bool vm_claim_page(void *va UNUSED) {
     return vm_do_claim_page(page);
 }
 
-/* Claim the PAGE and set up the mmu. */
+/// @brief claim_page()의 실제 로직을 수행합니다. 프레임을 할당하고, frame->page 및 page->frame 연결 등을 수행.
+/// @param page 매핑 및 할당할 보조 페이지 테이블의 페이지 구조체 포인터
+/// @return 성공 시 true, 프레임 할당 실패 또는 페이지 테이블 등록 실패 시 false
 static bool vm_do_claim_page(struct page *page) {
     struct frame *frame = vm_get_frame();
+    if (frame == NULL)
+        return false;
 
-    /* Set links */
+    /* 1. 가상 페이지 ↔ 프레임 연결 */
     frame->page = page;
     page->frame = frame;
 
-    /* TODO: Insert page table entry to map page's VA to frame's PA. */
+    /* 2. 가상 주소 ↔ 물리 주소(PA) 매핑 */
+    if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable)) {
+        /* 페이지 테이블 등록 실패 시 프레임 반납 */
+        vm_dealloc_frame(frame);
+        return false;
+    }
 
+    /* 3. 스왑인: 파일 읽기, 제로 페이지 채우기, 디스크에서 가져오기 등 */
     return swap_in(page, frame->kva);
 }
 


### PR DESCRIPTION

### 구현한 내용
- 페이지 프레임 할당, 페이지 테이블 매핑 및 스왑인을 수행하는 vm_do_claim_page 함수 구현
- 페이지 구조체에 해시 엘리먼트와 쓰기 가능 여부 멤버(hash_elem, writable) 추가

### 주요 변경 사항
- include/vm/vm.h	struct page에 hash_elem, bool writable 필드 추가
- vm_do_claim_page: 프레임 할당 및 페이지-프레임 연결, 페이지 테이블 매핑, 스왑인 처리 로직 구현


### 관련 파일
- include/vm/vm.h
- vm/vm.c