### PR TITLE
Pull Request: Add Lazy Page Allocation Logic with vm_alloc_page_with_initializer, uninit_new  and uninit_initialize,

### DIFF
--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -24,6 +24,22 @@ static const struct page_operations uninit_ops = {
 };
 
 /* DO NOT MODIFY this function */
+/**
+ * @brief Uninitialized 페이지를 초기화하여 struct page를 설정하는 함수
+ *
+ * @details 이 함수는 아직 메모리에 로드되지 않은(uninitialized) 페이지에 대해 `struct page`를 초기화한다.
+ * 해당 페이지를 이후 페이지 폴트 시 동적으로 초기화할 수 있도록 준비한다.
+ *
+ * 초기화된 `page`는 내부적으로 `uninit_page` 정보를 가지고 있으며,
+ * 실제 프레임은 아직 할당되지 않은 상태 (`frame = NULL`)이다.
+ *
+ * @param page          초기화할 대상 페이지 구조체 포인터
+ * @param va            사용자 가상 주소
+ * @param init          실제 초기화를 수행할 커스텀 함수 포인터 (lazy load 등)
+ * @param type          페이지 타입 (VM_ANON, VM_FILE 등)
+ * @param aux           초기화 시 전달할 보조 데이터 포인터
+ * @param initializer   `vm_type`에 따른 기본 페이지 초기화 함수 포인터 (예: anon_initializer 등)
+ */
 void uninit_new(struct page *page, void *va, vm_initializer *init, enum vm_type type, void *aux,
                 bool (*initializer)(struct page *, enum vm_type, void *)) {
     ASSERT(page != NULL);
@@ -40,6 +56,19 @@ void uninit_new(struct page *page, void *va, vm_initializer *init, enum vm_type 
 }
 
 /* Initalize the page on first fault */
+
+/**
+ * @brief 첫 접근 시 초기화되지 않은(uninit) 페이지를 실제로 초기화하는 함수
+ *
+ * 해당 페이지가 처음 접근되어 페이지 폴트가 발생했을 때 호출
+ * 페이지를 타입에 따라 실제로 초기화하고, 
+ * 만약 추가 초기화 함수가 등록되어 있다면 그 함수도 함께 호출
+ *
+ * @param page 초기화할 대상 페이지 구조체
+ * @param kva  해당 페이지가 매핑될 커널 가상 주소
+ *
+ * @return 초기화에 성공하면 true, 실패하면 false를 반환합니다.
+ */
 static bool uninit_initialize(struct page *page, void *kva) {
     struct uninit_page *uninit = &page->uninit;
 


### PR DESCRIPTION
### 변경 사항
`vm/vm.c`
- `vm_alloc_page_with_initializer()`
  - 사용자 가상 주소(`upage`)에 lazy loading이 가능한 uninit 페이지를 등록
  - VM_TYPE에 따라 적절한 초기화자 선택 (`anon_initializer`,` file_backed_initializer`)
  - `uninit_new()`을 호출하여 실제 초기화를 위한 구조 세팅
  - 이후 `spt_insert_page()`로 SPT에 등록
---
`vm/uninit.c`
- `uninit_new()`
  - `@brief, @details, @param` 등 한글 기반 `Doxygen `주석 추가
---
- `uninit_initialize()`
  - 페이지 폴트 발생 시점에 호출되어 페이지를 실제로 초기화하는 함수
  - `uninit_page`에 저장된 초기화자 함수 포인터를 기반으로 데이터 로딩 수행