### PR TITLE
Add: lazy_load, load 추가

### DIFF
--- a/userprog/process.c
+++ b/userprog/process.c
@@ -879,7 +879,11 @@ static bool lazy_load_segment(struct page *page, void *aux) {
 		
     uint8_t *kva = page->frame->kva;
     
-    file_read_at(file, kva, page_read_bytes, ofs);
+    if (file_read_at(file, kva, page_read_bytes, ofs) != (int)page_read_bytes) {
+        file_close(file);
+        free(segment_info);
+        return false; 
+    }
     
     memset(kva + page_read_bytes, 0, page_zero_bytes);
     

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -56,6 +56,13 @@ struct init_data {
     const char *file_name;
 };
 
+struct segment_info {
+    struct file *file;
+    off_t ofs;
+    size_t page_read_bytes;
+    size_t page_zero_bytes;
+};
+
 /* General process initializer for initd and other process. */
 static void process_init(void) {
     struct thread *current = thread_current();
@@ -846,26 +853,70 @@ static uint64_t *pop_stack(size_t size, struct intr_frame *if_) {
  * If you want to implement the function for only project 2, implement it on the
  * upper block. */
 
+/**
+ * @brief 페이지 폴트 발생 시 실제로 세그먼트를 디스크에서 로드하는 함수
+ * 
+ * 이 함수는 지연 로딩(Lazy Loading) 메커니즘의 핵심 함수로, 페이지 폴트가
+ * 발생했을 때 호출됩니다. 페이지 테이블에는 엔트리가 있지만 실제 물리 메모리에
+ * 로드되지 않은 페이지에 접근할 때 이 함수가 실행
+ * @param page 페이지 폴트가 발생한 페이지 구조체
+ * @param aux lazy_load_segment에서 전달된 세그먼트 정보 (struct segment_info *)
+ * @return 성공 시 true, 실패 시 false
+ * @note 이 함수는 페이지 폴트 핸들러에서 호출됨
+ * @note aux는 segment_info 구조체로 캐스팅하여 사용
+ * @note 파일 읽기 후 반드시 file_close()와 free() 호출하여 리소스 정리
+ */
 static bool lazy_load_segment(struct page *page, void *aux) {
     /* TODO: Load the segment from the file */
     /* TODO: This called when the first page fault occurs on address VA. */
     /* TODO: VA is available when calling this function. */
+
+    struct segment_info *segment_info = (struct segment_info *)aux;
+    struct file *file = segment_info->file;
+    off_t ofs = segment_info->ofs;
+    size_t page_read_bytes = segment_info->page_read_bytes;
+    size_t page_zero_bytes = segment_info->page_zero_bytes;
+		
+    uint8_t *kva = page->frame->kva;
+    
+    file_read_at(file, kva, page_read_bytes, ofs);
+    
+    memset(kva + page_read_bytes, 0, page_zero_bytes);
+    
+    file_close(file);
+    free(segment_info);
+	return true;
 }
 
-/* Loads a segment starting at offset OFS in FILE at address
- * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
- * memory are initialized, as follows:
- *
- * - READ_BYTES bytes at UPAGE must be read from FILE
- * starting at offset OFS.
- *
- * - ZERO_BYTES bytes at UPAGE + READ_BYTES must be zeroed.
- *
- * The pages initialized by this function must be writable by the
- * user process if WRITABLE is true, read-only otherwise.
- *
- * Return true if successful, false if a memory allocation error
- * or disk read error occurs. */
+/**
+ * @brief 파일에서 세그먼트를 가상 메모리에 지연 로딩 방식으로 로드
+ * 
+ * 이 함수는 파일의 OFS 오프셋에서 시작하는 세그먼트를 UPAGE 주소에 로드
+ * 지연 로딩(Lazy Loading) 메커니즘을 사용하여 페이지는 할당되지만 실제로는
+ * 첫 번째 페이지 폴트가 발생할 때까지 디스크에서 로드되지 않음
+ * 
+ * 총 READ_BYTES + ZERO_BYTES 바이트의 가상 메모리가 초기화:
+ * - UPAGE에서 시작하는 READ_BYTES 바이트는 파일의 OFS 오프셋에서 읽어야 함
+ * - UPAGE + READ_BYTES에서 시작하는 ZERO_BYTES 바이트는 0으로 초기화해야 함
+ * 
+ * 이 함수로 초기화된 페이지들은 WRITABLE이 true이면 사용자 프로세스가
+ * 쓰기 가능해야 하고, false이면 읽기 전용이어야 함.
+ * 
+ * @param file 세그먼트를 로드할 파일 포인터
+ * @param ofs 파일에서 세그먼트가 시작되는 오프셋
+ * @param upage 세그먼트가 로드될 가상 주소
+ * @param read_bytes 파일에서 읽을 바이트 수
+ * @param zero_bytes 0으로 초기화할 바이트 수
+ * @param writable 페이지를 쓰기 가능하게 할지 여부 (true: 쓰기 가능, false: 읽기 전용)
+ * 
+ * @return 성공 시 true, 메모리 할당 오류나 디스크 읽기 오류 발생 시 false
+ * 
+ * @note 이 함수는 지연 로딩을 사용합니다. 페이지는 페이지 테이블에 할당되지만
+ *       실제 디스크에서의 로딩은 첫 번째 페이지 폴트까지 지연
+ * @note 함수는 (read_bytes + zero_bytes)가 PGSIZE의 배수라고 가정
+ * @note 함수는 upage가 페이지 정렬되어 있다고 가정
+ * @note 함수는 ofs가 페이지 정렬되어 있다고 가정
+ */
 static bool load_segment(struct file *file, off_t ofs, uint8_t *upage, uint32_t read_bytes,
                          uint32_t zero_bytes, bool writable) {
     ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
@@ -879,12 +930,26 @@ static bool load_segment(struct file *file, off_t ofs, uint8_t *upage, uint32_t 
         size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
         size_t page_zero_bytes = PGSIZE - page_read_bytes;
 
-        /* TODO: Set up aux to pass information to the lazy_load_segment. */
-        void *aux = NULL;
-        if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, aux))
+        struct segment_info *aux = malloc(sizeof(struct segment_info));
+
+        if (aux == NULL) {
             return false;
+        }
+
+        aux->file = file_reopen(file);
+        aux->ofs = ofs;
+        aux->page_read_bytes = page_read_bytes;
+        aux->page_zero_bytes = page_zero_bytes;
+
+        /* TODO: Set up aux to pass information to the lazy_load_segment. */
+        if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, aux)){
+            file_close(aux->file);
+            free(aux);
+            return false;
+        }
 
         /* Advance. */
+        ofs += page_read_bytes;
         read_bytes -= page_read_bytes;
         zero_bytes -= page_zero_bytes;
         upage += PGSIZE;

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -736,6 +736,16 @@ static bool setup_stack(struct intr_frame *if_) {
     return success;
 }
 
+
+
+#else
+
+static bool install_page(void *upage, void *kpage, bool writable);
+
+/* From here, codes will be used after project 3.
+ * If you want to implement the function for only project 2, implement it on the
+ * upper block. */
+
 /* Adds a mapping from user virtual address UPAGE to kernel
  * virtual address KPAGE to the page table.
  * If WRITABLE is true, the user process may modify the page;
@@ -847,11 +857,6 @@ static uint64_t *pop_stack(size_t size, struct intr_frame *if_) {
 
     return if_->rsp;
 }
-
-#else
-/* From here, codes will be used after project 3.
- * If you want to implement the function for only project 2, implement it on the
- * upper block. */
 
 /**
  * @brief 페이지 폴트 발생 시 실제로 세그먼트를 디스크에서 로드하는 함수

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -166,9 +166,10 @@ static struct frame *vm_get_frame(void) {
         return frame;
     } else {
         frame = vm_evict_frame();
-        if (frame == NULL) {
-            PANIC("todo");
+        if (frame == NULL) { 
+            PANIC("vm_evict_frame returned NULL");
         }
+
         return frame;
     }
 }


### PR DESCRIPTION
### 1. `struct segment_info` 추가
- `process.c` 상단에 `struct segment_info` 구조체 정의
- 파일 포인터, 오프셋, 읽기 및 zero 바이트 정보를 담아 lazy loading에 전달

### 2. `lazy_load_segment()` 구현
- 페이지 폴트 발생 시 호출되는 함수
- `file_read_at()`으로 데이터를 직접 로드하고, 남은 바이트는 `memset()`으로 0 채움
- 이후 `file_close()` 및 `free()`로 리소스 정리

### 3. `load_segment()` 변경
- 기존 `file_read()` 대신 `vm_alloc_page_with_initializer()` 호출
- 각 페이지에 대해 `segment_info`를 동적으로 할당하고 `lazy_load_segment()`에 전달
- 파일 복사를 위해 `file_reopen()` 사용

### 4. `vm_get_frame()` 오류 메시지 개선
- frame 반환 실패 시 더 구체적인 panic 메시지 출력

---

## Why?

- 이 변경은 Project 3 (Virtual Memory)의 요구사항인 **Lazy Loading**을 충족하기 위한 것
- 페이지를 실제로 필요할 때까지 로드하지 않기 때문에 메모리 사용 최적화에 효과적

---

## Note

- segment_info는 각 페이지마다 새로 할당됨에 따라 메모리 누수가 없도록 `free()`가 필요
- file 핸들 또한 각 페이지마다 reopen 되었으므로 `file_close()` 반드시 호출해야 함

---

## Related Issues

- Project 3 (VM), Part 2 - Lazy Loading
