### PR TITLE
feat : anon_initializer, vm_anon_init 함수 구현

### DIFF
--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -4,7 +4,9 @@
 struct page;
 enum vm_type;
 
-struct anon_page {};
+struct anon_page {
+    size_t swap_slot_index;
+};
 
 void vm_anon_init(void);
 bool anon_initializer(struct page *page, enum vm_type type, void *kva);

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -2,12 +2,19 @@
 
 #include "devices/disk.h"
 #include "vm/vm.h"
+#include "threads/vaddr.h"
+#include "lib/kernel/bitmap.h"
 
 /* DO NOT MODIFY BELOW LINE */
 static struct disk *swap_disk;
 static bool anon_swap_in(struct page *page, void *kva);
 static bool anon_swap_out(struct page *page);
 static void anon_destroy(struct page *page);
+
+struct disk *swap_disk;
+struct bitmap *swap_table;
+// static struct lock swap_lock;
+
 
 /* DO NOT MODIFY this struct */
 static const struct page_operations anon_ops = {
@@ -18,17 +25,51 @@ static const struct page_operations anon_ops = {
 };
 
 /* Initialize the data for anonymous pages */
+/**
+ * @brief 익명 페이지 서브시스템을 초기화합니다.
+ * @details 시스템 부팅 시 한 번 호출되어 스왑 디스크를 설정
+ *          스왑 공간을 관리할 비트맵과 락을 초기화
+ */
 void vm_anon_init(void) {
     /* TODO: Set up the swap_disk. */
     swap_disk = NULL;
+    swap_disk = disk_get(1,1);
+
+    if(swap_disk == NULL){
+        return NULL;
+    }
+
+    size_t swap_slots_count = disk_size(swap_disk) / (PGSIZE / DISK_SECTOR_SIZE);
+
+    swap_table = bitmap_create(swap_slots_count);
+    if(swap_table == NULL){
+        PANIC("FAILED TO CREATE SWAP TABLE BITMAP");
+    }
+
+    //(필요시) 스왑 관리를 위한 락을 초기화
+    //lock_init(&swap_lock)
 }
 
-/* Initialize the file mapping */
+/*
+ * @brief 익명 페이지용 초기화 함수
+ * @param page 초기화할 페이지 구조체 포인터
+ * @param type 페이지 타입 (VM_ANON 등)
+ * @param kva 페이지가 연결될 커널 가상 주소 (kernel virtual address)
+ * @return 항상 true를 반환 (익명 페이지는 초기화 실패 가능성이 없음)
+ * @details
+ * - 이 함수는 uninit 페이지가 물리 프레임을 할당받을 때 호출
+ * - 페이지 타입에 맞는 `operations` 테이블을 설정
+ * - swap-out 이력이 없는 새 페이지임을 나타내기 위해 `swap_slot_index = (size_t)-1`로 초기화
+ * - 이 값은 페이지가 스왑된 적이 없음을 나타내며, 이후 스왑 아웃 시 swap 디스크의 인덱스로 갱신
+*/
 bool anon_initializer(struct page *page, enum vm_type type, void *kva) {
     /* Set up the handler */
     page->operations = &anon_ops;
 
     struct anon_page *anon_page = &page->anon;
+    anon_page->swap_slot_index = (size_t)-1;
+
+    return true;
 }
 
 /* Swap in the page by read contents from the swap disk. */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -58,7 +58,9 @@ err:
     return false;
 }
 
-/// @brief SPT에서 가상 주소 va에 해당하는 struct page *를 찾습니다.
+/*
+* @brief SPT에서 가상 주소 va에 해당하는 struct page *를 찾습니다.
+*/
 struct page *spt_find_page(struct supplemental_page_table *spt, void *va) {
     struct page temp_page;
     /* TODO: Fill this function. */
@@ -72,11 +74,12 @@ struct page *spt_find_page(struct supplemental_page_table *spt, void *va) {
     else
         return NULL;
 }
-
-/// @brief page->va를 기준으로 SPT에 페이지 등록, 중복 시 false
-/// @param spt (페이지를 등록할 보조 페이지 테이블의 포인터)
-/// @param page (등록할 페이지의 정보가 담긴 구조체의 포인터)
-/// @return 삽입에 성공하면 true, 가상 주소가 중복되어 실패하면 false
+/*
+* @brief page->va를 기준으로 SPT에 페이지 등록, 중복 시 false
+* @param spt (페이지를 등록할 보조 페이지 테이블의 포인터)
+* @param page (등록할 페이지의 정보가 담긴 구조체의 포인터)
+* @return 삽입에 성공하면 true, 가상 주소가 중복되어 실패하면 false
+*/
 bool spt_insert_page(struct supplemental_page_table *spt , struct page *page ) {
     int succ = false;
     struct hash_elem *result = hash_insert(&spt->spt_hash, &page->hash_elem);
@@ -198,10 +201,11 @@ void vm_dealloc_page(struct page *page) {
 }
 
 /* Claim the page that allocate on VA. */
-
-/// @brief 주어진 가상 주소에 해당하는 페이지를 프레임에 매핑하는 함수
-/// @param va 접근하려는 가상 주소
-/// @return 페이지를 성공적으로 매핑했다면 true, 실패했다면 false
+/*
+* @brief 주어진 가상 주소에 해당하는 페이지를 프레임에 매핑하는 함수
+* @param va 접근하려는 가상 주소
+* @return 페이지를 성공적으로 매핑했다면 true, 실패했다면 false
+*/
 bool vm_claim_page(void *va UNUSED) {
     /* TODO: Fill this function */
     struct page *page = spt_find_page(&thread_current()->spt, va);
@@ -212,9 +216,11 @@ bool vm_claim_page(void *va UNUSED) {
     return vm_do_claim_page(page);
 }
 
-/// @brief claim_page()의 실제 로직을 수행합니다. 프레임을 할당하고, frame->page 및 page->frame 연결 등을 수행.
-/// @param page 매핑 및 할당할 보조 페이지 테이블의 페이지 구조체 포인터
-/// @return 성공 시 true, 프레임 할당 실패 또는 페이지 테이블 등록 실패 시 false
+/*
+* @brief claim_page()의 실제 로직을 수행합니다. 프레임을 할당하고, frame->page 및 page->frame 연결 등을 수행.
+* @param page 매핑 및 할당할 보조 페이지 테이블의 페이지 구조체 포인터
+* @return 성공 시 true, 프레임 할당 실패 또는 페이지 테이블 등록 실패 시 false
+*/
 static bool vm_do_claim_page(struct page *page) {
     struct frame *frame = vm_get_frame();
     if (frame == NULL)
@@ -236,9 +242,10 @@ static bool vm_do_claim_page(struct page *page) {
 }
 
 /* Initialize new supplemental page table */
-
-/// @brief 보조 페이지 테이블을 초기화하는 함수
-/// @param spt 초기화할 보조 페이지 테이블 구조체 포인터
+/*
+* @brief 보조 페이지 테이블을 초기화하는 함수
+* @param spt 초기화할 보조 페이지 테이블 구조체 포인터
+*/
 void supplemental_page_table_init(struct supplemental_page_table *spt UNUSED) {
     hash_init(spt, page_hash, page_less, NULL);
 }
@@ -251,10 +258,12 @@ uint64_t page_hash(const struct hash_elem *e, void *aux) {
     return hash_bytes(page->va, sizeof *page->va);
 }
 
-/// @brief 페이지를 가상 주소 기준으로 비교하는 함수
-/// @param a 비교하는 해시 요소 1
-/// @param b 비교하는 해시 요소 2
-/// @return a의 가상 주소가 작다면 true, b의 가상 주소가 작다면 false
+/*
+* @brief 페이지를 가상 주소 기준으로 비교하는 함수
+* @param a 비교하는 해시 요소 1
+* @param b 비교하는 해시 요소 2
+* @return a의 가상 주소가 작다면 true, b의 가상 주소가 작다면 false
+*/
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux) {
     return hash_entry(a, struct page, hash_elem)->va 
             < hash_entry(b, struct page, hash_elem)->va;


### PR DESCRIPTION
## 1. vm_anon_init() 함수 추가 및 문서화
- 스왑 디스크 포인터 설정 (disk_get(1,1))
- 스왑 슬롯 수 계산: disk_size(swap_disk) / (PGSIZE / DISK_SECTOR_SIZE)
- 스왑 테이블 비트맵 생성: bitmap_create(swap_slots_count)
- doxygen 주석 추가 (@brief, @details)

## 2. anon_initializer() 함수 문서화
- page->operations에 anon_ops 설정
- anon_page->swap_slot_index = (size_t)-1로 초기화
- anon_page 구조체 생성
- doxygen 스타일 주석 추가 (@param, @return, @details 포함)