### PR TITLE
Add: supplemental_page_table_kill

### DIFF
--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -116,5 +116,6 @@ enum vm_type page_get_type(struct page *page);
 
 uint64_t page_hash(const struct hash_elem *e, void *aux);
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
+void page_destory(struct hash_elem *elem);
 
 #endif /* VM_VM_H */

--- a/lib/kernel/hash.c
+++ b/lib/kernel/hash.c
@@ -73,6 +73,14 @@ void hash_clear(struct hash *h, hash_action_func *destructor) {
    hash_insert(), hash_replace(), or hash_delete(), yields
    undefined behavior, whether done in DESTRUCTOR or
    elsewhere. */
+
+/**
+ * @brief 해시 테이블의 모든 항목을 제거하고 메모리 해제하는 함수
+ * @details destructor가 주어지면 각 항목에 대해 호출되며, 이후 해시 버킷 메모리 해제
+ * 
+ * @param h 제거할 해시 테이블의 포인터
+ * @param destructor 각 요소 제거 시 호출할 콜백 함수 포인터
+ */
 void hash_destroy(struct hash *h, hash_action_func *destructor) {
     if (destructor != NULL)
         hash_clear(h, destructor);

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -308,11 +308,50 @@ bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux) 
 }
 
 /* Copy supplemental page table from src to dst */
+/**
+ * @brief 진행 중
+ * @param dst 부모 프로세스의 SPT 포인터
+ * @param src 자식 프로세스의 SPT 포인터
+ * @return 
+ */
 bool supplemental_page_table_copy(struct supplemental_page_table *dst UNUSED,
-                                  struct supplemental_page_table *src UNUSED) {}
+                                  struct supplemental_page_table *src UNUSED) {
+    struct hash_iterator i;
+    hash_first(&i, &src->spt_hash);
+
+    while (hash_next(&i))
+    {
+        struct page *parent_page = hash_entry(hash_cur(&i) ,struct page, hash_elem);
+    }
+    
+}
 
 /* Free the resource hold by the supplemental page table */
+/**
+ * @brief SPT의 모든 페이지를 제거하는 함수
+ *          필요한 경우 디스크에 반영
+ * 
+ * @details page_destory를 통해 각 페이지에 대해 정리 및 메모리 해제를 수행
+ *          파일 기반 페이지의 경우 수정된 내용이 있다면 디스크에 기록
+ * 
+ * @param spt 제거할 보조 페이지 테이블 포인터
+ */
 void supplemental_page_table_kill(struct supplemental_page_table *spt UNUSED) {
     /* TODO: Destroy all the supplemental_page_table hold by thread and
      * TODO: writeback all the modified contents to the storage. */
+    hash_destroy(&spt->spt_hash, page_destory);
+}
+
+/**
+ * @brief 해시 테이블 항목 제거 시 호출되는 콜백 함수
+ *
+ * @details 페이지 타입별 destory를 호출하여 필요한 정리를 수행하고,
+ *          페이지 구조체의 메모리 해제
+ * 
+ * @param elem 제거할 페이지의 해시 요소 포인터
+ */
+void page_destory(struct hash_elem *elem) {
+    struct page *page = hash_entry(elem, struct page, hash_elem);
+    destroy(page);
+    free(page);
 }


### PR DESCRIPTION
`vm.c`
- `supplemental_page_table_kill()` 구현
- `hash_destroy()` 호출로 전체 페이지 메모리 해제 처리
- `page_destory()` 함수 추가 및 destroy()와 메모리 해제 수행

`hash.c`
- `hash_destroy()`에 `Doxygen `주석 추가
- `supplemental_page_table_copy()` 구현 중