### PR TITLE
feat : vm_try_handle_fault, vm_stack_growth 함수구현 및 thread 구조체 rsp_stack(스택 포인터) 추가

### DIFF
--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -107,6 +107,8 @@ struct thread {
     char name[16];             /* Name (for debugging purposes). */
     int priority;              /* Priority. */
 
+    void *rsp_stack;
+
     //	$feat/timer_sleep
     /** @brief 스레드를 깨울 tick 시각 초기화 시 0*/
     uint64_t wake_tick;


### PR DESCRIPTION
## 변경 사항 요약 (Summary of Changes)
1. 스택 확장 함수 구현
- vm_stack_growth() 함수를 기존 void에서 bool 반환형으로 수정하고, 스택 확장 로직을 구현해야함
- 페이지 폴트가 스택 접근으로 판단될 경우, vm_alloc_page()와 vm_claim_page()를 통해 새로운 페이지를 할당하고 매핑

2. 페이지 폴트 처리 함수 수정
- vm_try_handle_fault() 함수에서 다음 사항을 수행하도록 변경
- 유효하지 않은 접근(커널 주소, null, present fault 등)을 필터링
- SPT에 해당 페이지가 없는 경우, 스택 접근 조건 확인 후 스택 확장 시도
- 쓰기 요청인데 페이지가 read-only일 경우, false 반환
- 나머지 경우 vm_do_claim_page()로 메모리 할당

## 변경 이유 (Why These Changes Were Made)
- 프로젝트 3 요구사항에 따라 스택이 자동으로 성장해야 하는 기능을 구현해야함
- vm_try_handle_fault()가 단순히 존재하는 페이지만 처리하던 구조에서, 스택 접근에 의한 페이지 폴트도 적절히 처리하도록 개선
- vm_stack_growth() 함수의 반환값을 bool로 하여 실패 시 적절한 처리를 가능하게 구현

## 테스트 시나리오 및 기대 결과 (Test Scenarios & Expected Behavior)
- 유저 스택에 인접한 주소에서 폴트가 발생하면 → 새 페이지가 할당되어 스택이 확장됨 → 정상 동작
- 너무 낮은 주소(예: heap 영역)에서 폴트가 발생하면 → 스택 확장 시도 실패 → false 반환
- 쓰기 접근인데 read-only 페이지일 경우 → false 반환
- 페이지가 존재하고 적절한 접근이면 → vm_do_claim_page()를 통해 정상 할당됨



