### PR TITLE
fix: write, exit, shuffle, off / add : file_backed_swap_in, file_swap_backed_swap_out

### DIFF
--- a/vm/.test_status
+++ b/vm/.test_status
@@ -4,7 +4,7 @@ sm-full PASS
 rox-simple PASS
 page-linear PASS
 mmap-zero PASS
-mmap-exit FAIL
+mmap-exit PASS
 fork-multiple PASS
 pt-write-code PASS
 mmap-bad-fd PASS
@@ -14,7 +14,7 @@ read-bad-fd PASS
 priority-donate-multiple PASS
 args-multiple PASS
 lg-seq-random PASS
-syn-write FAIL
+syn-write PASS
 syn-remove PASS
 priority-donate-one PASS
 mmap-overlap PASS
@@ -46,9 +46,9 @@ priority-condvar PASS
 priority-donate-nest PASS
 rox-child PASS
 page-merge-par FAIL
-mmap-write FAIL
+mmap-write PASS
 alarm-single PASS
-lazy-file FAIL
+lazy-file PASS
 pt-bad-addr PASS
 read-normal PASS
 lazy-anon PASS
@@ -58,7 +58,7 @@ priority-donate-multiple2 PASS
 open-empty PASS
 mmap-zero-len PASS
 open-null PASS
-page-parallel FAIL
+page-parallel PASS
 sm-seq-random PASS
 page-merge-stk FAIL
 bad-write2 PASS
@@ -98,7 +98,7 @@ open-bad-ptr PASS
 mmap-inherit FAIL
 mmap-unmap PASS
 write-normal PASS
-mmap-off FAIL
+mmap-off PASS
 mmap-over-code PASS
 bad-read PASS
 mmap-close PASS
@@ -117,7 +117,7 @@ exit PASS
 write-bad-ptr PASS
 priority-donate-sema PASS
 lg-seq-block PASS
-mmap-shuffle FAIL
+mmap-shuffle PASS
 wait-simple PASS
 exec-once PASS
 args-many PASS
@@ -137,4 +137,4 @@ args-single PASS
 write-stdin PASS
 read-zero PASS
 bad-read2 PASS
-syn-read FAIL
+syn-read PASS


### PR DESCRIPTION
# Pull Request: 파일 기반 메모리 매핑 및 페이지 교체 기능 구현
## 개요
본 PR에서는 파일 매핑(mmap) 관련 코드의 핵심 함수들을 구현 및 개선하였습니다.

**file_backed_swap_in, file_backed_swap_out 함수 구현**
**do_munmap 함수의 더티 페이지 처리 및 자원 해제 로직 보완**
**lazy_load_segment 함수에서 불필요한 file_close 호출 주석 처리**
**헤더 포함 및 코드 스타일 일부 정리**

### 주요 변경사항 및 기능 설명
 1. `file_backed_swap_in(struct page *page, void *kva)` 

- 페이지 폴트 발생 시 호출되어 해당 페이지를 파일에서 읽어온다.
- file_read_at 함수로 파일의 특정 오프셋부터 read_bytes만큼 읽어와 kva(물리 메모리 버퍼)에 채움.
- 남은 zero_bytes만큼 0으로 초기화하여 페이지 데이터 완성.
- 읽기 실패 시 false 반환, 성공 시 true 반환.
- 페이지 프레임의 kva 포인터 갱신.

2. `file_backed_swap_out(struct page *page) `
- 페이지를 교체할 때 호출되어 페이지가 수정된 경우 파일에 내용을 기록한다.
- pml4_is_dirty로 해당 페이지의 더티 상태 검사.
- 더티 상태면 file_write_at으로 파일에 변경 내용 저장 후 더티 비트 클리어.
- 페이지 테이블에서 페이지 엔트리 제거(pml4_clear_page).
- 물리 메모리 해제 및 프레임 포인터 초기화.
- 성공 시 true 반환.

3. `do_munmap(void *addr)`
- do_mmap으로 매핑된 영역 해제 담당
- 매핑된 페이지 수를 mapped_page_count를 통해 확인하고 반복 처리.
- 각 페이지의 더티 상태 확인 후 파일에 내용 기록.
- 페이지 테이블 엔트리 제거, 물리 메모리 해제 및 SPT에서 페이지 제거 수행.
- 누락된 page->frame = NULL 처리 및 메모리 해제 free(p) 보완.

**4. lazy_load_segment 내 file_close 주석 처리**

- 페이지 로딩 시 file_close를 하지 않음으로써 파일 객체 중복 닫힘 방지 및 참조 유지.

기타
#include "threads/mmu.h" 헤더 추가로 pml4 관련 함수 사용 보장
