### PR TITLE
fix : lazy_load_segement에서 file_close 제거

### DIFF
--- a/userprog/process.c
+++ b/userprog/process.c
@@ -853,7 +853,6 @@ bool lazy_load_segment(struct page *page, void *aux) {
     
     memset(kva + page_read_bytes, 0, page_zero_bytes);
     
-    file_close(file);
     free(segment_info);
 	return true;
 }


### PR DESCRIPTION
# 이유: `lazy_load_segment`에서 `file_close()` 제거 필요성 문서화

`lazy_load_segment` 함수는 파일에서 페이지 데이터를 **필요할 때** (페이지 폴트 발생 시점에) 메모리로 읽어오는 역할을 수행합니다.  
이 함수 내에서 `file_close()`를 호출하면 다음과 같은 문제가 발생합니다.

---

## 1. 파일 객체의 참조 지속성 유지 필요

- `do_mmap()` 함수에서 파일을 매핑할 때, 같은 파일 객체를 여러 페이지가 공유합니다.
- `file_close()`는 해당 파일 객체의 참조를 해제하는 함수입니다.
- 만약 `lazy_load_segment()`에서 페이지 하나가 매핑될 때마다 `file_close()`를 호출하면,  
  그 파일 객체가 매핑된 여러 페이지에서 참조하는 파일 핸들이 중간에 닫혀버려  
  다른 페이지의 lazy loading에 영향을 주거나 오류가 발생할 수 있습니다.

---

## 2. mmap 영역 내 여러 페이지에서 동일 파일 공유

- mmap된 메모리 영역은 여러 페이지로 이루어져 있으며, 이들은 모두 같은 파일 객체를 참조합니다.
- `file_close()`를 페이지 단위로 호출하면 파일 참조 관리가 꼬여서, 다른 페이지들의 접근이 불가능해질 수 있습니다.

---

## 3. 파일 닫힘은 `munmap` 혹은 전체 매핑 해제 시점에서 처리

- 파일 객체의 닫힘은 mmap 해제 시점인 `do_munmap()` 함수에서 관리하는 것이 맞습니다.
- 이 함수에서 모든 매핑 페이지의 작업이 끝난 후, 파일을 닫거나 참조를 해제하는 처리를 하므로  
  중복 닫힘 문제를 방지할 수 있습니다.

---

# 결론

- `lazy_load_segment()` 내에서 `file_close()`를 호출하는 것은 mmap 구조와 참조 관리에 부합하지 않는 동작입니다.
- 따라서, `file_close()` 호출을 제거하고, mmap 해제 시점에만 파일 닫기를 수행해야 합니다.
- 이를 통해, 페이지 단위로 안전하게 lazy loading이 이루어지고,  
  파일 참조가 올바르게 유지되어 mmap 기능이 정상 동작할 수 있습니다.
