### PR TITLE
Pull Request: Fix mmap offset alignment validation in syscall.c

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,6 +46,16 @@
         "numeric": "c",
         "hash.h": "c",
         "round.h": "c",
-        "stdint.h": "c"
+        "stdint.h": "c",
+        "array": "c",
+        "compare": "c",
+        "functional": "c",
+        "ratio": "c",
+        "tuple": "c",
+        "type_traits": "c",
+        "utility": "c",
+        "*.test_config": "c",
+        "mmu.h": "c",
+        "main.h": "c"
     }
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -390,11 +390,10 @@ void *mmap_(void *addr, size_t length, int writable, int fd, off_t offset) {
 	if (file_size == -1 || file_size == 0) {
 		return NULL;
 	}
-	
-	// // 매핑 길이가 파일 크기를 초과하는지 확인
-	// if (offset >= file_size || length > file_size - offset) {
-	// 	return NULL;
-	// }
+
+	if (offset != pg_round_down(offset) || offset % PGSIZE != 0) {
+        return NULL;
+	}
 
 	size_t page_count = DIV_ROUND_UP(length, PGSIZE);
 

--- a/vm/.test_status
+++ b/vm/.test_status
@@ -126,7 +126,7 @@ fork-read PASS
 write-zero PASS
 alarm-multiple PASS
 create-exists PASS
-mmap-bad-off FAIL
+mmap-bad-off PASS
 open-normal PASS
 bad-jump PASS
 pt-big-stk-obj PASS


### PR DESCRIPTION
# Pull Request: Fix mmap offset alignment validation in syscall.c

## 변경 내용
- `mmap_()` 함수 내에서 mmap 호출 시 `offset`이 페이지 크기(`PGSIZE`)에 정확히 맞춰져 있는지 검사하는 로직을 추가했습니다.
- `offset`이 `pg_round_down(offset)`과 같고, `offset % PGSIZE == 0` 이어야만 정상 동작하도록 하여,
  조건을 만족하지 않으면 `NULL`을 반환하여 mmap 호출을 실패 처리합니다.

## 문제 배경
- 이전에는 `offset`이 페이지 정렬이 되어 있지 않은 값이 `do_mmap()`에 전달될 경우,
  내부 `ASSERT(offset % PGSIZE == 0)` 에서 커널 패닉이 발생하는 문제가 있었습니다.
- 이 문제는 `mmap-bad-off` 테스트에서 재현되었으며, 잘못된 오프셋으로 mmap 요청 시 시스템이 비정상 종료되었습니다.

## 해결 효과
- mmap 호출 전에 offset 유효성을 미리 검사하여, 커널 패닉 없이 syscall이 실패하도록 처리합니다.
- 안정성이 개선되고, `mmap-bad-off` 테스트를 정상 통과하게 되었습니다.

## 코드 변경 위치
- `userprog/syscall.c` 파일 내 `mmap_()` 함수의 예외 처리 부분에 `offset` 정렬 체크 추가
