### PR TITLE
Fix/mmap clean

### DIFF
--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -140,7 +140,7 @@ page_fault (struct intr_frame *f) {
 	write = (f->error_code & PF_W) != 0;
 	user = (f->error_code & PF_U) != 0;
 
-	if ((!not_present && write) || (fault_addr < 0x400000 || fault_addr >= USER_STACK)) {
+	if ((!not_present && write) || (fault_addr < 0x400000)) {
 		exit_(-1);
    	}
 #ifdef VM

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -142,17 +142,17 @@ page_fault (struct intr_frame *f) {
 
 	if ((!not_present && write) || (fault_addr < 0x400000 || fault_addr >= USER_STACK)) {
 		exit_(-1);
-   }
+   	}
 #ifdef VM
 	/* For project 3 and later. */
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present)) {
       return;
-   }
+   	}
 #endif
 
-   if (user) {
+   	if (user) {
       exit_(-1);
-   }
+   	}
 	/* Count page faults. */
 	page_fault_cnt++;
 

--- a/vm/.test_status
+++ b/vm/.test_status
@@ -121,7 +121,7 @@ mmap-shuffle PASS
 wait-simple PASS
 exec-once PASS
 args-many PASS
-mmap-clean FAIL
+mmap-clean PASS
 fork-read PASS
 write-zero PASS
 alarm-multiple PASS

--- a/vm/.test_status
+++ b/vm/.test_status
@@ -121,7 +121,7 @@ mmap-shuffle PASS
 wait-simple PASS
 exec-once PASS
 args-many PASS
-mmap-clean PASS
+mmap-clean FAIL
 fork-read PASS
 write-zero PASS
 alarm-multiple PASS


### PR DESCRIPTION
# 핀토스 mmap/munmap 시스템콜 디버깅 및 문제 분석 보고서
## 1. 개요
- mmap, munmap 관련 시스템콜 구현 중 munmap 호출 시 디버깅이 함수 시작점에서 곧바로 종료되는 문제 발생
- close 함수도 종단점 찍고 진입 시 디버깅 종료되어 함수 처리 문제 의심
- mmap 함수는 정상 동작 확인됨
## 2. 주요 디버깅 과정
### 2.1. write 시스템콜 디버깅
- `write_` 함수에 종단점 설정
- fd가 0보다 큰 값이나, 실제 fd 값은 1(표준 출력)임을 확인
- `putbuf(buffer, size)` 호출 후 정상 리턴
### 2.2. open 시스템콜 디버깅
- open 함수 진입 시 fd 값 128(파일 디스크립터 원본) 확인
- `process_add_file` 호출 후 fd 값이 3으로 변경됨
- fd 3 반환 확인, 정상적으로 파일 디스크립터 관리됨
### 2.3. close 시스템콜 디버깅
- close 함수 시작점에 종단점 설정했으나, 디버거가 함수 진입 후 곧바로 종료됨
- 함수 내부에서 치명적 예외 또는 커널 패닉 발생 추정
### 2.4. mmap 시스템콜 디버깅
- mmap 함수 진입 후 fd 값 69322434 확인
- `process_get_file` 호출 후 fd 3으로 정상 변환됨
- `DIV_ROUND_UP(length, PGSIZE)` 계산 시 page_count = 1
- 반복문 1회 실행 후 `do_mmap` 호출, 반환값 0x54321000 정상 확인
### 2.5. munmap 시스템콜 디버깅
- `munmap_` 함수 시작점에 종단점 찍자마자 디버깅 종료됨
- stack overflow, 치명적 예외, 잘못된 메모리 접근 등 원인 의심됨
## 3. 문제 원인 분석
- munmap 진입 시 디버깅 세션 종료되는 것은 보통 다음과 같은 원인 때문임
  - 스택 오버플로우 발생
  - 함수 진입 직후 잘못된 포인터 참조로 인한 커널 패닉
  - 유저 스택 접근 관련 예외 발생
- 디버깅 중 `page_fault` 핸들러 내 다음 조건문을 수정하니 통과
  ```c
  if ((!not_present && write) || (fault_addr < 0x400000)) {
      // ...
  }