### PR TITLE
Fix: 파일 시스템 잠금을 추가하고, 파일 생성 및 삭제 함수에서 잠금을 적용했습니다. 프로세스 종료 시 파일 디스크립터를…

### DIFF
--- a/include/lib/user/syscall.h
+++ b/include/lib/user/syscall.h
@@ -21,7 +21,7 @@ typedef int off_t;
 #define EXIT_SUCCESS 0          /* Successful execution. */
 #define EXIT_FAILURE 1          /* Unsuccessful execution. */
 
-
+extern struct lock filesys_lock; // 파일 읽기 쓰기 lock
 /* Projects 2 and later. */
 void halt_(void);
 void exit_(int status);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -218,17 +218,21 @@ int wait_(pid_t pid)
 bool create_(const char *file, unsigned initial_size)
 {
 	check_address(file);
-	
+	lock_acquire(&filesys_lock);
+	bool result = filesys_create(file, initial_size);
+	lock_release(&filesys_lock);
 	// 주어진 이름과 초기 크기로 새로운 파일 생성하는 함수
-	return filesys_create(file, initial_size);
+	return result;
 }
 
 bool remove_(const char *file)
 {
 	check_address(file);
-	
+	lock_acquire(&filesys_lock);
+	bool result = filesys_remove(file);
+	lock_release(&filesys_lock);
 	// 주어진 이름의 파일 삭제하는 함수
-	return filesys_remove(file);
+	return result;
 }
 
 int open_(const char *file)

--- a/vm/.test_status
+++ b/vm/.test_status
@@ -14,7 +14,7 @@ read-bad-fd PASS
 priority-donate-multiple PASS
 args-multiple PASS
 lg-seq-random PASS
-syn-write PASS
+syn-write FAIL
 syn-remove PASS
 priority-donate-one PASS
 mmap-overlap PASS
@@ -40,7 +40,7 @@ priority-donate-chain PASS
 create-bound PASS
 rox-multichild PASS
 lg-random PASS
-page-merge-seq PASS
+page-merge-seq FAIL
 pt-bad-read PASS
 priority-condvar PASS
 priority-donate-nest PASS
@@ -69,7 +69,7 @@ close-twice PASS
 mmap-over-data PASS
 args-none PASS
 mmap-kernel PASS
-swap-fork PASS
+swap-fork FAIL
 create-bad-ptr PASS
 read-stdout PASS
 priority-fifo PASS
@@ -109,7 +109,7 @@ priority-change PASS
 write-boundary PASS
 wait-killed PASS
 lg-full PASS
-swap-file FAIL
+swap-file PASS
 close-bad-fd PASS
 alarm-negative PASS
 multi-child-fd PASS
@@ -137,4 +137,4 @@ args-single PASS
 write-stdin PASS
 read-zero PASS
 bad-read2 PASS
-syn-read PASS
+syn-read FAIL

--- a/vm/file.c
+++ b/vm/file.c
@@ -5,6 +5,7 @@
 #include "threads/vaddr.h"
 #include "include/userprog/process.h"
 #include "threads/mmu.h"
+#include "lib/user/syscall.h"
 
 static bool file_backed_swap_in (struct page *page, void *kva);
 static bool file_backed_swap_out (struct page *page);
@@ -122,7 +123,9 @@ do_mmap (void *addr, size_t length, int writable,
 	// TODO: 2. fd에 대응하는 struct file * 구하기
 	// - 열린 파일 디스크립터 테이블에서 찾고, 실패 시 NULL 반환
 	// - file을 reopen하여 별도 참조를 유지 (중복 닫힘 방지)
+	lock_acquire(&filesys_lock);
 	struct file *f = file_reopen(file);
+	lock_release(&filesys_lock);
 	int total_page_count = length / PGSIZE;
 	if (length % PGSIZE != 0)
 		total_page_count += 1;
@@ -205,16 +208,16 @@ void do_munmap(void *addr) {
         }
 
         // 페이지 테이블에서 제거
-        pml4_clear_page(t->pml4, p->va);
+        // pml4_clear_page(t->pml4, p->va);
 
         // 물리 메모리 해제
         if (p->frame)
-            palloc_free_page(p->frame->kva);
+            // palloc_free_page(p->frame->kva);
             page->frame = NULL;
 
         // SPT에서 제거
-        hash_delete(&t->spt.spt_hash, &p->hash_elem);
-        free(p);
+        // hash_delete(&t->spt.spt_hash, &p->hash_elem);
+        // free(p);
     }
     //lock_release(&filesys_lock);
 }


### PR DESCRIPTION

---

## 한줄 요약

파일시스템 전역 락(`filesys_lock`)을 선언하고 원자적으로 보호하도록 시스템콜/VM의 일부 경로를 잠그는 변경입니다. 또한 `do_munmap()`에서 즉시 프레임/테이블 해제를 주석 처리해 **double-free를 우회**하는 임시 처리가 포함되어 있습니다. (동시에 테스트 상태 파일(`vm/.test_status`)에 일부 결과를 반영한 변경도 포함됨.)

> **중요**: 이 PR에는 안전성·정합성 문제를 우회하기 위한 임시 주석(메모리 해제/해시 삭제 주석)이 포함되어 있어 **merge 전 반드시** 다음 작업(프레임 해제 책임 일원화, spt 해제 수집 방식 적용)을 수행해야 합니다. 아래에 리스크·권장 수정 사항을 상세히 적어뒀습니다.

---

## 변경 파일 (요약)

* `include/lib/user/syscall.h`

  * `extern struct lock filesys_lock;` 추가
* `userprog/process.c`

  * `process_exit()`에서 파일 닫기/표준 정리 코드 정렬
  * `process_cleanup()`의 `#ifdef VM` 블록 수정 (주의: 동작 변경 의도 확인 필요)
  * `load()`에서 `filesys_open()` 호출을 `filesys_lock`으로 보호
* `userprog/syscall.c`

  * `create_()` / `remove_()`에서 `filesys_lock` 추가
  * (별도 커널 syscall 변경들을 포함)
* `vm/file.c`

  * `#include "lib/user/syscall.h"` 추가(전역 락 선언 사용)
  * `do_mmap()`에서 `file_reopen()`을 `filesys_lock`으로 감싸도록 변경
  * `do_munmap()` 내부에서 `pml4_clear_page`, `palloc_free_page`, `hash_delete`/`free` 호출을 주석 처리(임시)
* `vm/.test_status`

  * 몇몇 테스트의 PASS/FAIL 상태를 업데이트(레포지토리에 따라 이 파일은 커밋하면 안 되는 경우도 있으니 주의)

---

## 상세 변경 및 이유(파일별)

### 1) `include/lib/user/syscall.h`

```c
extern struct lock filesys_lock; // 파일 읽기 쓰기 lock
```

**이유:** 여러 모듈에서 동일한 `filesys_lock`을 사용하려고 전역 선언을 추가하였습니다.
**주의:** `syscall.h`는 userland 라이브러리 헤더인데 여기 선언을 추가하면 빌드/포팅 관점에서 어색할 수 있습니다. 전역 락 선언은 `process.h` 또는 커널 전용 헤더에 두는 것이 더 적절합니다. (후속 PR로 리팩터 권장)

---

### 2) `userprog/process.c`

* `process_exit()`

  * 모든 fd 닫기, `runn_file` 닫기, `palloc_free_multiple(curr->fd_table, FDPAGES)` 수행 후 `process_cleanup()` 호출.
* `process_cleanup()` 변경: `#ifdef VM` / `#else` 구조가 변경되어 VM이 정의되어 있을 때 `pml4_destroy()`가 실행되지 않게 보이는 편집이 존재합니다.

**주의:** 기존 동작은 (원래) VM일 때 `supplemental_page_table_kill()` 실행한 뒤 계속해서 `pml4_destroy()`까지 했습니다. 지금 수정된 분기는 `#ifdef VM`이 참이면 `supplemental_page_table_kill()`만 실행하고 `pml4_destroy()`를 건너뛰게 될 위험이 있어 보입니다. 의도된 변경인지 확인 필요합니다. (만약 의도적이라면 주석/코멘트로 이유 명시 필요)

* `load()`에 `lock_acquire(&filesys_lock)` / `lock_release(&filesys_lock)` 추가
  **이유:** 파일 열기(`filesys_open`) 도중 다른 파일 시스템 액세스와 경합이 발생할 수 있어 보호가 필요합니다.

---

### 3) `userprog/syscall.c`

* `create_()` / `remove_()` 에 파일시스템 락 적용:

```c
lock_acquire(&filesys_lock);
bool result = filesys_create(file, initial_size);
lock_release(&filesys_lock);
return result;
```

**이유:** 파일 생성/삭제는 파일시스템의 메타데이터를 변경하므로 전역 락으로 직렬화해야 데이터 손상 방지.

---

### 4) `vm/file.c`

* `#include "lib/user/syscall.h"` 추가: `filesys_lock` 참조를 위해 포함함. (앞서 언급: 더 적절한 헤더로 옮기길 권장)
* `do_mmap()`:

  * `file_reopen(file)` 호출을 `lock_acquire(&filesys_lock); ... lock_release(&filesys_lock);`로 보호.
  * **이유:** `file_reopen`의 내부가 파일시스템 구조를 건드릴 가능성이 있으므로 경쟁 방지.
* `do_munmap()`:

  * 기존에는 dirty 체크 후 `file_write_at()`로 writeback, 그리고 pml4\_clear\_page / palloc\_free\_page / hash\_delete / free를 했지만, 현재 diff에서는 pml4\_clear\_page / palloc\_free\_page / hash\_delete / free가 주석 처리되어 있음.
  * **이유(추정):** 주석 처리로 double-free / palloc assert 문제(NSP 발생)를 회피하려는 임시 조치로 보입니다.
  * **심각성:** 이 변경은 메모리/프레임을 해제하지 않아 메모리 누수와 SPT 정합성 문제를 일으킵니다. 반드시 대체 안전 구현(프레임 해제 책임 일원화, 수집-후-삭제 방식)으로 대체해야 합니다.

---

## 리스크 / 문제점 (중요)

1. **임시 주석 처리로 인한 메모리 누수 및 SPT 불일치**

   * `do_munmap`에서 페이지/프레임/해시 삭제가 주석 처리되어 매핑 해제가 정상적으로 일어나지 않습니다. 장기적으로는 누수·리소스 고갈·정합성 오류 초래.
2. **`process_cleanup`의 `#ifdef VM` 블록 변경 의도 불명**

   * `pml4_destroy()`가 VM 빌드에서 실행되지 않는다면 페이지 테이블 누수가 발생할 수 있음. 코드가 의도한 것인지 확인 필요.
3. **헤더 위치 문제**

   * `filesys_lock` 선언을 `include/lib/user/syscall.h`에 넣은 것은 적절치 않습니다. 이 선언은 커널 내부 전역으로 `process.h` 또는 `threads/` 쪽 적절한 커널 헤더로 옮겨야 합니다.
4. **`.test_status` 변경**

   * 테스트 상태 파일을 직접 수정하는 것은 문제를 은폐할 위험이 있으므로 권장하지 않습니다.

---

## 권장 조치(필수, Prioritized)

1. **(필수)** `do_munmap()`의 주석 처리된 부분을 원상복구하지 말고, 대신 안전한 해제 흐름을 구현:

   * *수집-후-삭제* 패턴: 먼저 삭제할 페이지 목록을 수집한 뒤 → 파일 쓰기/페이지 테이블 클리어/프레임 해제 → spt에서 삭제 → free(page).
   * 프레임 해제는 `vm_dealloc_frame()` 같은 한 곳에서만 수행하도록 책임을 통일.
2. **(필수)** `filesys_lock`의 선언 위치를 옮기기:

   * `process.h` 또는 `filesys/filesys.h` 등에 `extern struct lock filesys_lock;` 선언하고, 한 .c 파일(예: `userprog/syscall.c` 또는 `filesys/filesys.c`)에서 `struct lock filesys_lock;` 을 정의. 현재 추가한 헤더는 되돌리고 올바른 위치로 이동 권장.
3. **(권장)** `process_cleanup()`의 `#ifdef VM` 블록을 원래 의도대로, 즉 VM일 때는 `supplemental_page_table_kill()`을 호출한 뒤 `pml4_destroy()`를 항상 호출하도록 정리.
4. **(권장)** `do_mmap()` 등에서 `filesys_lock`을 쓸 때는 lock을 잡은 상태에서도 오래 걸리는 작업을 하지 않도록 설계(예: 큰 블록 I/O는 락 해제 후 진행하거나 finer-grained locking 고려).
5. **(권장)** `.test_status` 변경은 되돌리고, CI에서 failing 항목을 코드로 고쳐서 PASS로 만들 것.

---

## 테스트/검증 가이드 (로컬에서 실행 권장)

1. 전체 빌드:

```bash
make
```

2. VM 관련 테스트만 실행(예시):

```bash
pintos -- run 'mmap-write'       # 또는 repository 테스트 스크립트에 맞춰 실행
make check -k vm                # 또는 프로젝트의 테스트 명령
```

3. 실패 시 우선 로그(콘솔 출력)를 캡처하고, 특히 `palloc_free_page` 어사션/`file_write_at` 반환값(0) 관련 로그가 있는지 확인하세요.

---

## 코드 리뷰 질문(검토자에게 물어볼 것)

* `process_cleanup()`의 `#ifdef VM` 변경은 의도된 동작인가요? (VM 빌드 시 pml4\_destroy를 생략하려는 의도인지)
* `filesys_lock` 선언을 `include/lib/user/syscall.h`에 둔 이유는 무엇인가요? 헤더 위치 이동을 원하시면 어디로 옮기면 좋을까요?
* `do_munmap()`에서 주석 처리한 부분은 임시 우회인지, 아니면 다른 방식으로 해제 책임을 옮기려는 의도인지요?

---

## TODO / 후속 PR(우선순위 높은 것)

1. **(핵심)** `do_munmap()`의 정식 안전 구현과 `vm_dealloc_frame` / `vm_dealloc_page` 일원화 구현 PR. (우선순위 최상)
2. `filesys_lock` 선언을 적절한 커널 헤더로 이동 & 불필요한 userland exposure 제거.
3. `process_cleanup()` 조건부 로직 검토 및 문서화.


